### PR TITLE
Enhance logging consistency and add custom headers

### DIFF
--- a/MiniTwitch.Common/WebSocketClient.cs
+++ b/MiniTwitch.Common/WebSocketClient.cs
@@ -58,7 +58,7 @@ public sealed class WebSocketClient : IAsyncDisposable
 
         // Set URI for reconnects
         _uri = uri;
-        Log(LogLevel.Trace, "Connecting to {uri} ...", uri);
+        Log(LogLevel.Trace, "Connecting to {Uri} ...", uri);
 
         // Try connecting
         try
@@ -120,7 +120,7 @@ public sealed class WebSocketClient : IAsyncDisposable
 
         _reconnecting = true;
 
-        Log(LogLevel.Critical, "The WebSocket client is restarting in {delay}", delay);
+        Log(LogLevel.Critical, "The WebSocket client is restarting in {Delay}", delay);
         // Attempt to disconnect
         await Disconnect(cancellationToken);
 
@@ -167,7 +167,7 @@ public sealed class WebSocketClient : IAsyncDisposable
             }
             catch (WebSocketException wse)
             {
-                Log(LogLevel.Critical, "An error occurred while receiving data from the WebSocket connection: {msg}",
+                Log(LogLevel.Critical, "An error occurred while receiving data from the WebSocket connection: {Message}",
                     wse.Message);
                 break;
             }
@@ -251,6 +251,6 @@ public sealed class WebSocketClient : IAsyncDisposable
         }
 
         await OnDisconnect.Invoke();
-        Log(LogLevel.Debug, "Disposed {name}", nameof(WebSocketClient));
+        Log(LogLevel.Debug, "Disposed {Name}", nameof(WebSocketClient));
     }
 }

--- a/MiniTwitch.Helix/Internal/HelixApiClient.cs
+++ b/MiniTwitch.Helix/Internal/HelixApiClient.cs
@@ -34,6 +34,7 @@ public sealed class HelixApiClient
         _tokenValidationUrl = tokenValidationUrl;
         _logger = logger;
         this.UserId = userId;
+        GetLogger().BeginScope($"Helix-UserId={this.UserId}");
     }
 
     public void ChangeToken(string newToken, long newUserId)
@@ -202,6 +203,6 @@ public sealed class HelixApiClient
         }
     }
 
-    private void Log(LogLevel level, string template, params object[] properties) => GetLogger().Log(level, "[MiniTwitch.Helix] " + template, properties);
+    private void Log(LogLevel level, string template, params object[] properties) => GetLogger().Log(level, template, properties);
     private ILogger GetLogger() => _logger ?? this.Logger;
 }

--- a/MiniTwitch.Irc/IrcMembershipClient.cs
+++ b/MiniTwitch.Irc/IrcMembershipClient.cs
@@ -179,13 +179,13 @@ public sealed class IrcMembershipClient : IAsyncDisposable
     {
         if (!_ws.IsConnected)
         {
-            Log(LogLevel.Error, "Failed to join channel {channel}:  Not connected.", channel);
+            Log(LogLevel.Error, "Failed to join channel {Channel}:  Not connected.", channel);
             return;
         }
 
         if (!_manager.CanJoin())
         {
-            Log(LogLevel.Warning, "Waiting to join #{channel}: Configured ratelimit of {rate} joins/10s is hit", channel, _options.JoinRateLimit);
+            Log(LogLevel.Warning, "Waiting to join #{Channel}: Configured ratelimit of {Rate} joins/10s is hit", channel, _options.JoinRateLimit);
             await Task.Delay(TimeSpan.FromSeconds(30 / _options.JoinRateLimit), cancellationToken);
             await JoinChannel(channel, cancellationToken);
             return;
@@ -205,7 +205,7 @@ public sealed class IrcMembershipClient : IAsyncDisposable
     {
         if (!_ws.IsConnected)
         {
-            Log(LogLevel.Error, "Failed to join channels {channels}:  Not connected.", string.Join(',', channels));
+            Log(LogLevel.Error, "Failed to join channels {Channels}:  Not connected.", string.Join(',', channels));
             return;
         }
 
@@ -224,12 +224,12 @@ public sealed class IrcMembershipClient : IAsyncDisposable
     {
         if (!_ws.IsConnected)
         {
-            Log(LogLevel.Error, "Failed to part channel {channel}: Not connected.", channel);
+            Log(LogLevel.Error, "Failed to part channel {Channel}: Not connected.", channel);
             return Task.CompletedTask;
         }
 
         if (_joinedChannels.Remove(channel))
-            Log(LogLevel.Debug, "Removed #{channel} from joined channels list.", channel);
+            Log(LogLevel.Debug, "Removed #{Channel} from joined channels list.", channel);
 
         return _ws.SendAsync($"PART #{channel}", cancellationToken: cancellationToken).AsTask();
     }


### PR DESCRIPTION
- Added `LoggingHeader` property to `DefaultMiniTwitchLogger`.
- Modified `BeginScope` in `DefaultMiniTwitchLogger` to set `LoggingHeader`.
- Standardized placeholder names in `WebSocketClient`, `IrcClient`, `IrcMembershipClient`, and `PubSubClient`.
- Added logging scopes in `HelixApiClient`, `IrcClient`, and `PubSubClient`.
- Updated `DisposeAsync` methods in `IrcClient` and `PubSubClient` to dispose of logging scopes.