### PR TITLE
helix: fix CustomReward related issues

### DIFF
--- a/MiniTwitch.Helix/Enums/RewardRedemptionStatus.cs
+++ b/MiniTwitch.Helix/Enums/RewardRedemptionStatus.cs
@@ -1,5 +1,8 @@
-﻿namespace MiniTwitch.Helix.Enums;
+﻿using System.Text.Json.Serialization;
 
+namespace MiniTwitch.Helix.Enums;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum RewardRedemptionStatus
 {
     CANCELED,

--- a/MiniTwitch.Helix/Responses/CustomReward.cs
+++ b/MiniTwitch.Helix/Responses/CustomReward.cs
@@ -9,7 +9,7 @@ public class CustomReward : BaseResponse<CustomReward.Reward>
         [property: JsonPropertyName("broadcaster_name")] string BroadcasterDisplayName,
         [property: JsonPropertyName("broadcaster_login")] string BroadcasterName,
         long BroadcasterId,
-        string RewardId,
+        string Id,
         Image? Image,
         string BackgroundColor,
         bool IsEnabled,

--- a/MiniTwitch.Helix/Responses/CustomRewardRedemptions.cs
+++ b/MiniTwitch.Helix/Responses/CustomRewardRedemptions.cs
@@ -12,16 +12,13 @@ public class CustomRewardRedemptions : PaginableResponse<CustomRewardRedemptions
         long BroadcasterId,
         [property: JsonPropertyName("user_name")] string UserDisplayName,
         [property: JsonPropertyName("user_login")] string UserName,
-      long UserId,
+        long UserId,
         string Id,
         string UserInput,
         DateTime RedeemedAt,
-        RedemptionReward Reward
-    )
-    {
-        internal string status = "None";
-        public RewardRedemptionStatus Status => Enum.Parse<RewardRedemptionStatus>(status);
-    };
+        RedemptionReward Reward,
+        RewardRedemptionStatus Status
+    );
 
     public record RedemptionReward(
         string Title,


### PR DESCRIPTION
This PR fixes 2 issues;

1. CustomReward had a regression when JsonPropertyName was removed https://github.com/Foretack/MiniTwitch/commit/bf111df7c1953f57591817bbae167abb538deed9
2. CustomRewardRedemption would error as "None" is not a valid enum value and the property was never properly populated

I haven't investigated if any other regressions happened during aforementioned refactor