### PR TITLE
helix: fix enum converter parsing and add more detailed exceptions

### DIFF
--- a/MiniTwitch.Helix/Internal/Json/Converters.cs
+++ b/MiniTwitch.Helix/Internal/Json/Converters.cs
@@ -101,21 +101,20 @@ internal class EnumConverter<TEnum> : JsonConverter<TEnum>
     {
         if (reader.TokenType == JsonTokenType.String)
         {
-            ReadEnum(reader.GetString());
+            return ReadEnum(reader.GetString());
         }
 
-        throw new JsonException();
+        throw new JsonException($"Expected string token but got {reader.TokenType}");
     }
-
 
     internal static TEnum ReadEnum(string? enumString)
     {
         if (Enum.TryParse(typeof(TEnum), SnakeCase.Instance.ConvertFromCase(enumString), out object? enumMember))
         {
-            return (TEnum)enumMember!;
+            return (TEnum)enumMember;
         }
 
-        return default!;
+        throw new JsonException($"Cannot convert '{enumString}' to enum {typeof(TEnum).Name}");
     }
 
     public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)

--- a/MiniTwitch.Helix/Internal/Json/Converters.cs
+++ b/MiniTwitch.Helix/Internal/Json/Converters.cs
@@ -63,7 +63,8 @@ internal class LongConverter : JsonConverter<long>
         return long.TryParse(chars, out var l) ? l : default;
     }
 
-    public override void Write(Utf8JsonWriter writer, long value, JsonSerializerOptions options) => writer.WriteStringValue(value.ToString());
+    public override void Write(Utf8JsonWriter writer, long value, JsonSerializerOptions options) =>
+        writer.WriteStringValue(value.ToString());
 }
 
 /// <summary>
@@ -89,7 +90,8 @@ internal class IntConverter : JsonConverter<int>
         return int.TryParse(chars, out var i) ? i : default;
     }
 
-    public override void Write(Utf8JsonWriter writer, int value, JsonSerializerOptions options) => writer.WriteStringValue(value.ToString());
+    public override void Write(Utf8JsonWriter writer, int value, JsonSerializerOptions options) =>
+        writer.WriteStringValue(value.ToString());
 }
 
 /// <summary>
@@ -114,7 +116,7 @@ internal class EnumConverter<TEnum> : JsonConverter<TEnum>
             return (TEnum)enumMember;
         }
 
-        throw new JsonException($"Cannot convert '{enumString}' to enum {typeof(TEnum).Name}");
+        return default!;
     }
 
     public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)
@@ -134,7 +136,8 @@ internal class TimeSpanToSeconds : JsonConverter<TimeSpan>
     public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         => throw new NotSupportedException("Converter should only be used for writing");
 
-    public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options) => writer.WriteNumberValue(AsSeconds(value));
+    public override void Write(Utf8JsonWriter writer, TimeSpan value, JsonSerializerOptions options) =>
+        writer.WriteNumberValue(AsSeconds(value));
 
     internal static int AsSeconds(TimeSpan ts) => (int)ts.TotalSeconds;
 }

--- a/MiniTwitch.Helix/Responses/EventSubSubscriptions.cs
+++ b/MiniTwitch.Helix/Responses/EventSubSubscriptions.cs
@@ -1,5 +1,6 @@
 using System.Text.Json.Serialization;
 using MiniTwitch.Helix.Enums;
+using MiniTwitch.Helix.Internal.Json;
 using MiniTwitch.Helix.Models;
 
 namespace MiniTwitch.Helix.Responses;
@@ -14,13 +15,14 @@ public class EventSubSubscriptions : PaginableResponse<EventSubSubscriptions.Sub
     public int Total { get; init; }
 
     public record Condition(
-        [property: JsonPropertyName("broadcaster_user_id")] long BroadcasterId,
-      long UserId
+        [property: JsonPropertyName("broadcaster_user_id")]
+        string BroadcasterId,
+        string UserId
     );
 
     public record Subscription(
         string Id,
-        [property: JsonConverter(typeof(JsonStringEnumConverter))]
+        [property: JsonConverter(typeof(EnumConverter<EventSubStatus>))]
         EventSubStatus Status,
         string Type,
         string Version,
@@ -32,6 +34,10 @@ public class EventSubSubscriptions : PaginableResponse<EventSubSubscriptions.Sub
 
     public record Transport(
         string Method,
-        string Callback
+        string? Callback,
+        string? Secret,
+        string? SessionId,
+        string? ConnectedAt,
+        string? DisconnectedAt
     );
 }


### PR DESCRIPTION
- This also fixes EventSubSubscriptions.Condition serialization, api expects strings.

Here is an example stack trace I got before the changes.

```log
[22:31:53 ERR] Failed to get eventsub subscriptions. Deserialization failure.
                                                                             The JSON value could not be converted to MiniTwitch.Helix.Responses.EventSubSubscriptions+Subscription. Path: $.data[0].status | LineNumber: 0 | BytePositionInLine: 97.
                                                                                             at System.Text.Json.ThrowHelper.ThrowJsonException(String message)
   at System.Text.Json.Serialization.Converters.EnumConverter`1.Read(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue)
   at System.Text.Json.Serialization.JsonConverter`1.TryReadAsObject(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, Object& value)
   at System.Text.Json.Serialization.Converters.LargeObjectWithParameterizedConstructorConverter`1.ReadAndCacheConstructorArgument(ReadStack& state, Utf8JsonReader& reader, JsonParameterInfo jsonParameterInfo)
   at System.Text.Json.Serialization.Converters.ObjectWithParameterizedConstructorConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue)
   at System.Text.Json.Serialization.JsonCollectionConverter`2.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, TCollection& value)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue)
   at System.Text.Json.Serialization.Metadata.JsonPropertyInfo`1.ReadJsonAndSetMember(Object obj, ReadStack& state, Utf8JsonReader& reader)
   at System.Text.Json.Serialization.Converters.ObjectDefaultConverter`1.OnTryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value)
   at System.Text.Json.Serialization.JsonConverter`1.TryRead(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options, ReadStack& state, T& value, Boolean& isPopulatedValue)
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, T& value, JsonSerializerOptions options, ReadStack& state)
   at System.Text.Json.Serialization.Metadata.JsonTypeInfo`1.Deserialize(Utf8JsonReader& reader, ReadStack& state)
   at System.Text.Json.JsonSerializer.ReadFromSpan[TValue](ReadOnlySpan`1 utf8Json, JsonTypeInfo`1 jsonTypeInfo, Nullable`1 actualByteCount)
   at System.Text.Json.JsonSerializer.Deserialize[TValue](JsonElement element, JsonSerializerOptions options)
   at MiniTwitch.Helix.Internal.HelixResultFactory.Create[T](HelixApiClient client, RequestData request, HelixEndpoint endpoint, CancellationToken cancellationToken) in C:\Users\[redacted]\Projects\MiniTwitch\MiniTwitch.Helix\Internal\HelixResultFactory.cs:line 36
   ```
   
   And here is the raw json output that it was attempting to parse
   ```json
   {
  "total": 5,
  "data": [
    {
      "id": "[redacted-id]",
      "status": "websocket_disconnected",
      "type": "channel.channel_points_automatic_reward_redemption.add",
      "version": "1",
      "condition": {
        "broadcaster_user_id": "[redacted-user-id]"
      },
      "created_at": "2025-03-24T02:17:50.324489567Z",
      "transport": {
        "method": "websocket",
        "session_id": "[redacted-session]",
        "connected_at": "2025-03-24T02:17:50Z",
        "disconnected_at": "2025-03-24T02:19:21Z"
      },
      "cost": 0
    },
    {
      "id": "[redacted-id]",
      "status": "websocket_disconnected",
      "type": "channel.channel_points_custom_reward.add",
      "version": "1",
      "condition": {
        "broadcaster_user_id": "[redacted-user-id]"
      },
      "created_at": "2025-03-24T02:20:04.960072211Z",
      "transport": {
        "method": "websocket",
        "session_id": "[redacted-session]",
        "connected_at": "2025-03-24T02:20:04Z",
        "disconnected_at": "2025-03-24T02:21:31Z"
      },
      "cost": 0
    },
    {
      "id": "[redacted-id]",
      "status": "websocket_disconnected",
      "type": "channel.channel_points_custom_reward.add",
      "version": "1",
      "condition": {
        "broadcaster_user_id": "[redacted-user-id]"
      },
      "created_at": "2025-03-24T02:23:32.111639668Z",
      "transport": {
        "method": "websocket",
        "session_id": "[redacted-session]",
        "connected_at": "2025-03-24T02:23:32Z",
        "disconnected_at": "2025-03-24T02:25:26Z"
      },
      "cost": 0
    },
    {
      "id": "[redacted-id]",
      "status": "websocket_disconnected",
      "type": "channel.channel_points_custom_reward.add",
      "version": "1",
      "condition": {
        "broadcaster_user_id": "[redacted-user-id]"
      },
      "created_at": "2025-03-24T02:26:02.266095617Z",
      "transport": {
        "method": "websocket",
        "session_id": "[redacted-session]",
        "connected_at": "2025-03-24T02:26:02Z",
        "disconnected_at": "2025-03-24T02:29:18Z"
      },
      "cost": 0
    },
    {
      "id": "[redacted-id]",
      "status": "websocket_disconnected",
      "type": "channel.channel_points_custom_reward.add",
      "version": "1",
      "condition": {
        "broadcaster_user_id": "[redacted-user-id]"
      },
      "created_at": "2025-03-24T02:29:37.077784575Z",
      "transport": {
        "method": "websocket",
        "session_id": "[redacted-session]",
        "connected_at": "2025-03-24T02:29:36Z",
        "disconnected_at": "2025-03-24T02:29:47Z"
      },
      "cost": 0
    }
  ],
  "max_total_cost": 10,
  "total_cost": 0,
  "pagination": {}
}
```